### PR TITLE
Introduce shadowsocks request and decoding capabilities

### DIFF
--- a/regions/build.gradle.kts
+++ b/regions/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 publishing {
     repositories {
         maven {
-            url = uri("https://maven.pkg.github.com/xvpn/cpz_pia-mobile_shared_regions/")
+            url = uri("https://maven.pkg.github.com/pia-foss/mobile-shared-regions")
             credentials {
                 username = System.getenv("GITHUB_USERNAME")
                 password = System.getenv("GITHUB_TOKEN")

--- a/regions/src/androidMain/kotlin/com/privateinternetaccess/regions/internals/MessageVerificator.kt
+++ b/regions/src/androidMain/kotlin/com/privateinternetaccess/regions/internals/MessageVerificator.kt
@@ -25,7 +25,7 @@ import java.security.spec.InvalidKeySpecException
 import java.security.spec.X509EncodedKeySpec
 
 
-actual object MessageVerificator {
+internal actual object MessageVerificator {
 
     actual fun verifyMessage(message: String, key: String): Boolean {
         try {

--- a/regions/src/androidMain/kotlin/com/privateinternetaccess/regions/internals/PersistenceRegionsDataSource.kt
+++ b/regions/src/androidMain/kotlin/com/privateinternetaccess/regions/internals/PersistenceRegionsDataSource.kt
@@ -31,14 +31,13 @@ internal actual class PersistenceRegionsDataSource(
         }
     }
 
-    override fun storeJsonEntry(jsonEntry: String) = cache.edit()
-        .putString(RegionsDataSourceFactory.DEFAULT_CACHE_ENTRY_KEY, jsonEntry)
+    override fun storeJsonEntry(key: String, jsonEntry: String) = cache.edit()
+        .putString(key, jsonEntry)
         .apply()
 
-    override fun retrieveJsonEntry(): String? = cache.getString(RegionsDataSourceFactory.DEFAULT_CACHE_ENTRY_KEY, null)
+    override fun retrieveJsonEntry(key: String): String? = cache.getString(key, null)
 
     companion object {
         private const val TAG: String = "PersistenceRegionsDataSource"
-        private const val DEFAULT_CACHE_ENTRY_KEY: String = "persist_region_entry"
     }
 }

--- a/regions/src/androidMain/kotlin/com/privateinternetaccess/regions/internals/PingPerformer.kt
+++ b/regions/src/androidMain/kotlin/com/privateinternetaccess/regions/internals/PingPerformer.kt
@@ -27,7 +27,7 @@ import kotlin.coroutines.CoroutineContext
 import kotlin.system.measureTimeMillis
 
 
-actual class PingPerformer : CoroutineScope {
+internal actual class PingPerformer : CoroutineScope {
 
     companion object {
         private const val REGIONS_PING_PORT = 443

--- a/regions/src/androidMain/kotlin/com/privateinternetaccess/regions/internals/RegionsDataSourceFactoryImpl.kt
+++ b/regions/src/androidMain/kotlin/com/privateinternetaccess/regions/internals/RegionsDataSourceFactoryImpl.kt
@@ -1,7 +1,6 @@
 package com.privateinternetaccess.regions.internals
 
 import com.privateinternetaccess.regions.PlatformInstancesProvider
-import com.privateinternetaccess.regions.internals.RegionsDataSourceFactory.Companion.DEFAULT_CACHE_ENTRY_KEY
 
 internal actual class RegionsDataSourceFactoryImpl actual constructor(
     platformProvider: PlatformInstancesProvider?,

--- a/regions/src/commonMain/kotlin/com/privateinternetaccess/regions/RegionsUtils.kt
+++ b/regions/src/commonMain/kotlin/com/privateinternetaccess/regions/RegionsUtils.kt
@@ -18,17 +18,17 @@ package com.privateinternetaccess.regions
  *  Internet Access Mobile Client.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import com.privateinternetaccess.regions.model.RegionsResponse
+import com.privateinternetaccess.regions.model.VpnRegionsResponse
 import kotlinx.serialization.json.Json
 
 
 object RegionsUtils {
 
-    fun stringify(regionsResponse: RegionsResponse) =
-        Json { encodeDefaults = true }.encodeToString(RegionsResponse.serializer(), regionsResponse)
+    fun stringify(regionsResponse: VpnRegionsResponse) =
+        Json { encodeDefaults = true }.encodeToString(VpnRegionsResponse.serializer(), regionsResponse)
 
     fun parse(regionsResponseString: String) =
-        Json { ignoreUnknownKeys = true }.decodeFromString(RegionsResponse.serializer(), regionsResponseString)
+        Json { ignoreUnknownKeys = true }.decodeFromString(VpnRegionsResponse.serializer(), regionsResponseString)
 
     internal fun isErrorStatusCode(code: Int): Boolean {
         when (code) {

--- a/regions/src/commonMain/kotlin/com/privateinternetaccess/regions/internals/InMemoryRegionsCacheDataSource.kt
+++ b/regions/src/commonMain/kotlin/com/privateinternetaccess/regions/internals/InMemoryRegionsCacheDataSource.kt
@@ -1,22 +1,41 @@
 package com.privateinternetaccess.regions.internals
 
-import com.privateinternetaccess.regions.model.RegionsResponse
+import com.privateinternetaccess.regions.model.ShadowsocksRegionsResponse
+import com.privateinternetaccess.regions.model.VpnRegionsResponse
+
 
 internal class InMemoryRegionsCacheDataSource: RegionsCacheDataSource {
-    private var cacheEntry: CacheEntry? = null
+    private var vpnRegionsCacheEntry: CacheEntry? = null
+    private var shadowsocksRegionsEntry: List<ShadowsocksRegionsResponse> = emptyList()
 
-    override fun saveRegion(locale: String, regionsResponse: RegionsResponse) {
-        this.cacheEntry = CacheEntry(
+    override fun saveVpnRegions(locale: String, regionsResponse: VpnRegionsResponse) {
+        this.vpnRegionsCacheEntry = CacheEntry(
             locale = locale,
             regionsResponse = regionsResponse
         )
     }
 
-    override fun getRegion(locale: String?): Result<RegionsResponse> {
-        val cacheEntry: CacheEntry? = this.cacheEntry
+    override fun getVpnRegions(locale: String?): Result<VpnRegionsResponse> {
+        val cacheEntry: CacheEntry? = this.vpnRegionsCacheEntry
         return when {
             cacheEntry != null && (locale == null || cacheEntry.locale == locale) -> Result.success(cacheEntry.regionsResponse)
             else -> Result.failure(CacheError(locale))
+        }
+    }
+
+    override fun saveShadowsocksRegions(
+        locale: String,
+        response: List<ShadowsocksRegionsResponse>
+    ) {
+        this.shadowsocksRegionsEntry = response
+    }
+
+    override fun getShadowsocksRegions(
+        locale: String?
+    ): Result<List<ShadowsocksRegionsResponse>> {
+        return when {
+            shadowsocksRegionsEntry.isNotEmpty() -> Result.success(shadowsocksRegionsEntry)
+            else -> Result.failure(Error("Shadowsocks entry is empty"))
         }
     }
 }

--- a/regions/src/commonMain/kotlin/com/privateinternetaccess/regions/internals/MessageVerificator.kt
+++ b/regions/src/commonMain/kotlin/com/privateinternetaccess/regions/internals/MessageVerificator.kt
@@ -1,0 +1,10 @@
+package com.privateinternetaccess.regions.internals
+
+internal expect object MessageVerificator {
+
+    /**
+     * @param message String. Message to verify.
+     * @param key String. Verification key.
+     */
+    fun verifyMessage(message: String, key: String): Boolean
+}

--- a/regions/src/commonMain/kotlin/com/privateinternetaccess/regions/internals/PingPerformer.kt
+++ b/regions/src/commonMain/kotlin/com/privateinternetaccess/regions/internals/PingPerformer.kt
@@ -1,0 +1,15 @@
+package com.privateinternetaccess.regions.internals
+
+internal expect class PingPerformer() {
+
+    /**
+     * @param endpoints Map<String, List<String>>. Key: Region. List<String>: Endpoints within the
+     * region.
+     * @param callback Map<String, List<Pair<String, Long>>>. Key: Region.
+     * List<Pair<String, Long>>>: Endpoints and latencies within the region.
+     */
+    fun pingEndpoints(
+        endpoints: Map<String, List<String>>,
+        callback: (result: Map<String, List<Pair<String, Long>>>) -> Unit
+    )
+}

--- a/regions/src/commonMain/kotlin/com/privateinternetaccess/regions/internals/RegionHttpClient.kt
+++ b/regions/src/commonMain/kotlin/com/privateinternetaccess/regions/internals/RegionHttpClient.kt
@@ -1,0 +1,19 @@
+package com.privateinternetaccess.regions.internals
+
+import io.ktor.client.HttpClient
+
+
+internal expect object RegionHttpClient {
+
+    /**
+     * @param certificate String?. Certificate required for pinning capabilities.
+     * @param pinnedEndpoint Pair<String, String>?. Contains endpoint as first,
+     * commonName as second.
+     *
+     * @return `Pair<HttpClient?, Exception?>`.
+     */
+    fun client(
+        certificate: String? = null,
+        pinnedEndpoint: Pair<String, String>? = null
+    ): Pair<HttpClient?, Exception?>
+}

--- a/regions/src/commonMain/kotlin/com/privateinternetaccess/regions/internals/RegionsCacheDataSource.kt
+++ b/regions/src/commonMain/kotlin/com/privateinternetaccess/regions/internals/RegionsCacheDataSource.kt
@@ -1,9 +1,8 @@
-@file:Suppress(names = ["CanSealedSubClassBeObject"])
-
 package com.privateinternetaccess.regions.internals
 
 import com.privateinternetaccess.regions.PlatformInstancesProvider
-import com.privateinternetaccess.regions.model.RegionsResponse
+import com.privateinternetaccess.regions.model.ShadowsocksRegionsResponse
+import com.privateinternetaccess.regions.model.VpnRegionsResponse
 import kotlinx.serialization.Serializable
 
 
@@ -11,24 +10,20 @@ internal class CacheError(locale: String?) : Throwable(message = if (locale.isNu
 
 internal interface RegionsDataSourceFactory {
     fun newInMemoryDataSource(): RegionsCacheDataSource
-    fun newPersistenceRegionsDataSource(
-        preferenceName: String?
-    ): RegionsCacheDataSource
-
-    companion object {
-        const val DEFAULT_CACHE_ENTRY_KEY: String = "persist_region_entry"
-    }
+    fun newPersistenceRegionsDataSource(preferenceName: String?): RegionsCacheDataSource
 }
 
 internal interface RegionsCacheDataSource {
-    fun saveRegion(locale: String, regionsResponse: RegionsResponse)
-    fun getRegion(locale: String?): Result<RegionsResponse>
+    fun saveVpnRegions(locale: String, response: VpnRegionsResponse)
+    fun getVpnRegions(locale: String?): Result<VpnRegionsResponse>
+    fun saveShadowsocksRegions(locale: String, response: List<ShadowsocksRegionsResponse>)
+    fun getShadowsocksRegions(locale: String?): Result<List<ShadowsocksRegionsResponse>>
 }
 
 @Serializable
 internal data class CacheEntry(
     val locale: String,
-    val regionsResponse: RegionsResponse
+    val regionsResponse: VpnRegionsResponse
 )
 
 internal expect class RegionsDataSourceFactoryImpl(

--- a/regions/src/commonMain/kotlin/com/privateinternetaccess/regions/model/ShadowsocksRegionsResponse.kt
+++ b/regions/src/commonMain/kotlin/com/privateinternetaccess/regions/model/ShadowsocksRegionsResponse.kt
@@ -1,0 +1,37 @@
+package com.privateinternetaccess.regions.model
+
+/*
+ *  Copyright (c) 2023 Private Internet Access, Inc.
+ *
+ *  This file is part of the Private Internet Access Mobile Client.
+ *
+ *  The Private Internet Access Mobile Client is free software: you can redistribute it and/or
+ *  modify it under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  The Private Internet Access Mobile Client is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ *  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ *  details.
+ *
+ *  You should have received a copy of the GNU General Public License along with the Private
+ *  Internet Access Mobile Client.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+
+@Serializable
+public data class ShadowsocksRegionsResponse(
+    @SerialName("region")
+    val region: String,
+    @SerialName("host")
+    val host: String,
+    @SerialName("port")
+    val port: Int,
+    @SerialName("key")
+    val key: String,
+    @SerialName("cipher")
+    val cipher: String
+)

--- a/regions/src/commonMain/kotlin/com/privateinternetaccess/regions/model/VpnRegionsResponse.kt
+++ b/regions/src/commonMain/kotlin/com/privateinternetaccess/regions/model/VpnRegionsResponse.kt
@@ -23,7 +23,7 @@ import kotlinx.serialization.Serializable
 
 
 @Serializable
-public data class RegionsResponse(
+public data class VpnRegionsResponse(
     @SerialName("groups")
     val groups: Map<String, List<ProtocolDetails>> = mutableMapOf(),
     @SerialName("regions")

--- a/regions/src/commonTest/kotlin/com/privateinternetaccess/regions/RegionsAPITest.kt
+++ b/regions/src/commonTest/kotlin/com/privateinternetaccess/regions/RegionsAPITest.kt
@@ -67,13 +67,27 @@ class RegionsAPITest {
     }
 
     @Test
+    fun `Test missing shadowsocks request path information`() {
+        assertFailsWith(Exception::class) {
+            RegionsBuilder()
+                .setEndpointProvider(MockEndpointProvider())
+                .setCertificate("test-certificate")
+                .setUserAgent("test-user-agent")
+                .setMetadataRequestPath("metadata-request-path")
+                .setVpnRegionsRequestPath("vpn-regions-request-path")
+                .build()
+        }
+    }
+
+    @Test
     fun `Test missing metadata request path information`() {
         assertFailsWith(Exception::class) {
             RegionsBuilder()
                 .setEndpointProvider(MockEndpointProvider())
                 .setCertificate("test-certificate")
                 .setUserAgent("test-user-agent")
-                .setRegionsListRequestPath("regions-list-request-path")
+                .setVpnRegionsRequestPath("vpn-regions-request-path")
+                .setShadowsocksRegionsRequestPath("shadowsocks-regions-request-path")
                 .build()
         }
     }
@@ -95,7 +109,8 @@ class RegionsAPITest {
             .setEndpointProvider(MockEndpointProvider())
             .setCertificate("test-certificate")
             .setUserAgent("test-user-agent")
-            .setRegionsListRequestPath("regions-list-request-path")
+            .setVpnRegionsRequestPath("vpn-regions-request-path")
+            .setShadowsocksRegionsRequestPath("shadowsocks-regions-request-path")
             .setMetadataRequestPath("metadata-request-path")
             .build()
     }

--- a/regions/src/iosMain/kotlin/com/privateinternetaccess/regions/PlatformInstancesProvider.kt
+++ b/regions/src/iosMain/kotlin/com/privateinternetaccess/regions/PlatformInstancesProvider.kt
@@ -1,7 +1,7 @@
 package com.privateinternetaccess.regions
 
 /**
- * iOs specific interface to provide platform specific instances to the library.
+ * iOS specific interface to provide platform specific instances to the library.
  *
  * Note: An instance implementing this interface does not need to be provided to a RegionsBuilder instance, because this provider is not used in the iOs implementation yet.
  */

--- a/regions/src/iosMain/kotlin/com/privateinternetaccess/regions/internals/PersistenceRegionsDataSource.kt
+++ b/regions/src/iosMain/kotlin/com/privateinternetaccess/regions/internals/PersistenceRegionsDataSource.kt
@@ -15,11 +15,11 @@ internal actual class PersistenceRegionsDataSource(
         }
     }
 
-    override fun storeJsonEntry(jsonEntry: String) {
+    override fun storeJsonEntry(key: String, jsonEntry: String) {
         throw UnsupportedOperationException("not yet implemented")
     }
 
-    override fun retrieveJsonEntry(): String? {
+    override fun retrieveJsonEntry(key: String): String? {
         throw UnsupportedOperationException("not yet implemented")
     }
 

--- a/regions/src/tvosMain/kotlin/com/privateinternetaccess/regions/PlatformInstancesProvider.kt
+++ b/regions/src/tvosMain/kotlin/com/privateinternetaccess/regions/PlatformInstancesProvider.kt
@@ -1,7 +1,7 @@
 package com.privateinternetaccess.regions
 
 /**
- * iOs specific interface to provide platform specific instances to the library.
+ * tvOS specific interface to provide platform specific instances to the library.
  *
  * Note: An instance implementing this interface does not need to be provided to a RegionsBuilder instance, because this provider is not used in the iOs implementation yet.
  */

--- a/regions/src/tvosMain/kotlin/com/privateinternetaccess/regions/internals/PersistenceRegionsDataSource.kt
+++ b/regions/src/tvosMain/kotlin/com/privateinternetaccess/regions/internals/PersistenceRegionsDataSource.kt
@@ -15,11 +15,11 @@ internal actual class PersistenceRegionsDataSource(
         }
     }
 
-    override fun storeJsonEntry(jsonEntry: String) {
+    override fun storeJsonEntry(key: String, jsonEntry: String) {
         throw UnsupportedOperationException("not yet implemented")
     }
 
-    override fun retrieveJsonEntry(): String? {
+    override fun retrieveJsonEntry(key: String): String? {
         throw UnsupportedOperationException("not yet implemented")
     }
 


### PR DESCRIPTION
## Summary

It introduces the API to request the list of shadowsocks servers we support, along with its logic to persist a known state.

## Tests

- [x] Update its entry point unit tests. Confirm it succeeds.
- [x] Using a test app. Perform a request to fetch vpn servers. Confirm it succeeds.
- [x] Using a test app. Perform a request to fetch shadowsocks servers. Confirm it succeeds.