### PR TITLE
Fix compiler errors on xcode15

### DIFF
--- a/regions/src/iosMain/kotlin/com/privateinternetaccess/regions/internals/MessageVerificator.kt
+++ b/regions/src/iosMain/kotlin/com/privateinternetaccess/regions/internals/MessageVerificator.kt
@@ -28,7 +28,7 @@ import platform.Security.*
 import platform.posix.memcpy
 
 @OptIn(kotlinx.cinterop.ExperimentalForeignApi::class)
-actual object MessageVerificator {
+internal actual object MessageVerificator {
 
     actual fun verifyMessage(message: String, key: String): Boolean {
         val publicKeyData = NSData.create(

--- a/regions/src/iosMain/kotlin/com/privateinternetaccess/regions/internals/PingPerformer.kt
+++ b/regions/src/iosMain/kotlin/com/privateinternetaccess/regions/internals/PingPerformer.kt
@@ -19,7 +19,7 @@ package com.privateinternetaccess.regions.internals
  */
 
 
-actual class PingPerformer {
+internal actual class PingPerformer {
 
     companion object {
         private const val REGIONS_PING_PORT = 443

--- a/regions/src/iosMain/kotlin/com/privateinternetaccess/regions/internals/RegionHttpClient.kt
+++ b/regions/src/iosMain/kotlin/com/privateinternetaccess/regions/internals/RegionHttpClient.kt
@@ -21,9 +21,8 @@ package com.privateinternetaccess.regions.internals
 import com.privateinternetaccess.regions.internals.Regions.Companion.REQUEST_TIMEOUT_MS
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.darwin.*
-import io.ktor.client.engine.ios.Ios
-import io.ktor.client.plugins.*
 import io.ktor.client.engine.ios.*
+import io.ktor.client.plugins.*
 import kotlinx.cinterop.*
 import platform.CoreFoundation.*
 import platform.Foundation.*
@@ -36,7 +35,7 @@ internal actual object RegionHttpClient {
         certificate: String?,
         pinnedEndpoint: Pair<String, String>?
     ): Pair<HttpClient?, Exception?> {
-        return Pair(HttpClient(Ios) {
+        return Pair(HttpClient(Darwin) {
             expectSuccess = false
             install(HttpTimeout) {
                 requestTimeoutMillis = REQUEST_TIMEOUT_MS

--- a/regions/src/tvosMain/kotlin/com/privateinternetaccess/regions/internals/MessageVerificator.kt
+++ b/regions/src/tvosMain/kotlin/com/privateinternetaccess/regions/internals/MessageVerificator.kt
@@ -28,7 +28,7 @@ import platform.Security.*
 import platform.posix.memcpy
 
 @OptIn(kotlinx.cinterop.ExperimentalForeignApi::class)
-actual object MessageVerificator {
+internal actual object MessageVerificator {
 
     actual fun verifyMessage(message: String, key: String): Boolean {
         val publicKeyData = NSData.create(

--- a/regions/src/tvosMain/kotlin/com/privateinternetaccess/regions/internals/PingPerformer.kt
+++ b/regions/src/tvosMain/kotlin/com/privateinternetaccess/regions/internals/PingPerformer.kt
@@ -19,7 +19,7 @@ package com.privateinternetaccess.regions.internals
  */
 
 
-actual class PingPerformer {
+internal actual class PingPerformer {
 
     companion object {
         private const val REGIONS_PING_PORT = 443


### PR DESCRIPTION
This PR fixes compiler errors when trying to build the XCFramework on tvOS with XCode 15.
It also fixes the crash that was happening when instantiating the library on PIA iOS