### PR TITLE
PIA-1187: Make ping result list synchronized

### DIFF
--- a/regions/build.gradle.kts
+++ b/regions/build.gradle.kts
@@ -38,7 +38,7 @@ android {
 @OptIn(org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi::class)
 kotlin {
     group = "com.kape.android"
-    version = "1.6.4"
+    version = "1.6.3"
 
     // Enable the default target hierarchy.
     // It's a template for all possible targets and their shared source sets hardcoded in the

--- a/regions/build.gradle.kts
+++ b/regions/build.gradle.kts
@@ -38,7 +38,7 @@ android {
 @OptIn(org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi::class)
 kotlin {
     group = "com.kape.android"
-    version = "1.6.2"
+    version = "1.6.4"
 
     // Enable the default target hierarchy.
     // It's a template for all possible targets and their shared source sets hardcoded in the

--- a/regions/src/androidMain/kotlin/com/privateinternetaccess/regions/internals/PingPerformer.kt
+++ b/regions/src/androidMain/kotlin/com/privateinternetaccess/regions/internals/PingPerformer.kt
@@ -44,7 +44,8 @@ internal actual class PingPerformer : CoroutineScope {
         callback: (result: Map<String, List<Pair<String, Long>>>) -> Unit
     ) {
         async {
-            val result = mutableMapOf<String, List<Pair<String, Long>>>()
+            val syncResult =
+                Collections.synchronizedMap(mutableMapOf<String, List<Pair<String, Long>>>())
             val requests: MutableList<Job> = mutableListOf()
             for ((region, endpointsInRegion) in endpoints) {
                 val syncRegionEndpointsResults =
@@ -59,12 +60,12 @@ internal actual class PingPerformer : CoroutineScope {
                             REGIONS_PING_TIMEOUT.toLong()
                         } ?: latency
                         syncRegionEndpointsResults.add(Pair(it, latency))
-                        result[region] = syncRegionEndpointsResults
+                        syncResult[region] = syncRegionEndpointsResults
                     })
                 }
             }
             requests.joinAll()
-            launch(Dispatchers.Main) { callback(result) }
+            launch(Dispatchers.Main) { callback(syncResult) }
         }
     }
 


### PR DESCRIPTION
## Summary

It updates the list containing the ping results to be synchronized as all pings are being invoked concurrently, which is causing a race conditions on `add` causing for some results to be added as `null`.

## Sanity Tests

- [x] Make a local release. Import it on the legacy app. Confirm we can't reproduce the issue with pings not returning the callback.
- [x] Make a local release. Import it on the re-arch app. Confirm we can't reproduce the issue with pings not returning the callback.