### PR TITLE
PIA-839: Add region's iso within the shadowsocks server response

### DIFF
--- a/regions/src/commonMain/kotlin/com/privateinternetaccess/regions/internals/Regions.kt
+++ b/regions/src/commonMain/kotlin/com/privateinternetaccess/regions/internals/Regions.kt
@@ -321,9 +321,11 @@ public class Regions internal constructor(
 
         val localizedRegions = mutableListOf<ShadowsocksRegionsResponse>()
         for (region in shadowsocksRegionsResponse) {
-            val regionTranslation = shadowsocksRegionTranslation(region.region, vpnRegionsResponse)
-                ?: continue
-            localizedRegions.add(region.copy(region = regionTranslation))
+            shadowsocksRegionTranslation(region.region, vpnRegionsResponse)?.let { translation ->
+                shadowsocksRegionIso(region.region, vpnRegionsResponse)?.let { iso ->
+                    localizedRegions.add(region.copy(iso = iso, region = translation))
+                }
+            }
         }
         return Result.success(localizedRegions)
     }
@@ -369,9 +371,20 @@ public class Regions internal constructor(
         vpnRegionsResponse: VpnRegionsResponse
     ): String? {
         for (region in vpnRegionsResponse.regions) {
-
-            if (region.id.startsWith(shadowsocksRegion, ignoreCase = true)) {
+            if (region.id.equals(shadowsocksRegion, ignoreCase = true)) {
                 return region.name
+            }
+        }
+        return null
+    }
+
+    private fun shadowsocksRegionIso(
+        shadowsocksRegion: String,
+        vpnRegionsResponse: VpnRegionsResponse
+    ): String? {
+        for (region in vpnRegionsResponse.regions) {
+            if (region.id.equals(shadowsocksRegion, ignoreCase = true)) {
+                return region.country
             }
         }
         return null

--- a/regions/src/commonMain/kotlin/com/privateinternetaccess/regions/model/ShadowsocksRegionsResponse.kt
+++ b/regions/src/commonMain/kotlin/com/privateinternetaccess/regions/model/ShadowsocksRegionsResponse.kt
@@ -18,20 +18,15 @@ package com.privateinternetaccess.regions.model
  *  Internet Access Mobile Client.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 
 @Serializable
 public data class ShadowsocksRegionsResponse(
-    @SerialName("region")
+    val iso: String = "world",
     val region: String,
-    @SerialName("host")
     val host: String,
-    @SerialName("port")
     val port: Int,
-    @SerialName("key")
     val key: String,
-    @SerialName("cipher")
     val cipher: String
 )


### PR DESCRIPTION
## Summary

We need to expose the region iso in order to be able to show the appropiate region flag within the client.

## Sanity Test

- [x] Use a version of the library containing these changes with the client. Confirm we can map the flags accordingly.