### PR TITLE
PIA-1900: Ping just one meta endpoint per region

### DIFF
--- a/regions/src/commonMain/kotlin/com/privateinternetaccess/regions/RegionsAPI.kt
+++ b/regions/src/commonMain/kotlin/com/privateinternetaccess/regions/RegionsAPI.kt
@@ -259,12 +259,10 @@ public data class RegionJsonFallback(
  * Data class defining the response object for a ping request. @see `fun pingRequests(...)`.
  *
  * @param region `String`.
- * @param endpoint `String`.
  * @param latency `String`.
  */
 public data class RegionLowerLatencyInformation(
     val region: String,
-    val endpoint: String,
     val latency: Long
 )
 

--- a/regions/src/commonMain/kotlin/com/privateinternetaccess/regions/internals/PingPerformer.kt
+++ b/regions/src/commonMain/kotlin/com/privateinternetaccess/regions/internals/PingPerformer.kt
@@ -3,13 +3,11 @@ package com.privateinternetaccess.regions.internals
 internal expect class PingPerformer() {
 
     /**
-     * @param endpoints Map<String, List<String>>. Key: Region. List<String>: Endpoints within the
-     * region.
-     * @param callback Map<String, List<Pair<String, Long>>>. Key: Region.
-     * List<Pair<String, Long>>>: Endpoints and latencies within the region.
+     * @param endpoints Map<String, String>. Key: Region. String: Endpoint to ping in the region.
+     * @param callback Map<String, Long>. Key: Region. Value: Latency.
      */
     fun pingEndpoints(
-        endpoints: Map<String, List<String>>,
-        callback: (result: Map<String, List<Pair<String, Long>>>) -> Unit
+        endpoints: Map<String, String>,
+        callback: (result: Map<String, Long>) -> Unit
     )
 }

--- a/regions/src/iosMain/kotlin/com/privateinternetaccess/regions/internals/PingPerformer.kt
+++ b/regions/src/iosMain/kotlin/com/privateinternetaccess/regions/internals/PingPerformer.kt
@@ -26,10 +26,10 @@ internal actual class PingPerformer {
     }
 
     actual fun pingEndpoints(
-        endpoints: Map<String, List<String>>,
-        callback: (result: Map<String, List<Pair<String, Long>>>) -> Unit
+        endpoints: Map<String, String>,
+        callback: (result: Map<String, Long>) -> Unit
     ) {
-        val result = mutableMapOf<String, List<Pair<String, Long>>>()
+        val result = mutableMapOf<String, Long>()
         callback(result)
     }
 }

--- a/regions/src/tvosMain/kotlin/com/privateinternetaccess/regions/internals/PingPerformer.kt
+++ b/regions/src/tvosMain/kotlin/com/privateinternetaccess/regions/internals/PingPerformer.kt
@@ -26,10 +26,10 @@ internal actual class PingPerformer {
     }
 
     actual fun pingEndpoints(
-        endpoints: Map<String, List<String>>,
-        callback: (result: Map<String, List<Pair<String, Long>>>) -> Unit
+        endpoints: Map<String, String>,
+        callback: (result: Map<String, Long>) -> Unit
     ) {
-        val result = mutableMapOf<String, List<Pair<String, Long>>>()
+        val result = mutableMapOf<String, Long>()
         callback(result)
     }
 }


### PR DESCRIPTION
## Summary

As per title. It updates the ping logic to ping just one meta endpoint per region instead of all of them as we only need the latency per region, not per server. This would also help reduce the amount of network noise related to it.

## Sanity Tests

- [x] Using the previous logic. Add some logs to get the number of ping requests. With the current response, that number is 349
- [x] Using this logic. Add some logs to get the number of ping requests. With the current response, that number is 166. Which is around the number of regions we support.