### PR TITLE
Bump version to `1.7.0`

### DIFF
--- a/regions/build.gradle.kts
+++ b/regions/build.gradle.kts
@@ -38,7 +38,7 @@ android {
 @OptIn(org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi::class)
 kotlin {
     group = "com.kape.android"
-    version = "1.6.5"
+    version = "1.7.0"
 
     // Enable the default target hierarchy.
     // It's a template for all possible targets and their shared source sets hardcoded in the


### PR DESCRIPTION
## Summary

As per title, it bumps the version to `1.6.5`.

## Sanity Tests

N/A